### PR TITLE
Publish to npm via Tekton CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,6 @@ Starts an interactive node terminal with the library available to use
 ```
 
 
-### Publishing
+### CI/CD
 
-- `yarn clean && yarn build`
-- Bump package.json version
-- Merge to ~~main~~ master
-- Checkout master, `git pull`
-- `git tag -a vx.x.x -m "x.x.x"`
-- `git push origin --tags`
-- Create vx.x.x release for tag in github
-- Move .npmrc off to fulcrum.npmrc and `npm login` (1password) support@fulcrumapp.com
-- `npm publish`
-- Move fulcrum.npmrc back to .npmrc and `npm login` (1password) support@fulcrumapp.com
-- `npm publish`
+Publishing to npm and artifactory is handled automatically by our CI Tekton pipeline. 

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -1,0 +1,1 @@
+outputType: "npm"


### PR DESCRIPTION
# What?

- Add a `ci/config.yaml` file to trigger the ci-publish pipeline (npm packages)
- Update README

# Why?

We use CI/CD tekton pipelines to publish other packages, why not this one? 

# Testing

Does a pipeline kick off when this PR is opened for real? Does it complete successfully? 