### PR TITLE
Update README to remove artifactory step

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,5 @@ Starts an interactive node terminal with the library available to use
   - `npm login` using creds from "npmjs (fulcrumapp)" in 1password
   - use "support@fulcrumapp.com" for the email address when prompted
   - `npm publish`
-- Publish to artifactory
+- Restore your .npmrc file
   - `mv $HOME/fulcrum.npmrc $HOME/.npmrc`
-  - `npm publish`


### PR DESCRIPTION
# What?

- Removes a set in the README that is no longer relevant

# Why?

The step is out of date and causes a 404 when trying to execute it. The hope is this change will avoid confusion for future releasers.

# Testing

Read it and see if it makes sense
