### PR TITLE
chore: update CI unit test and lint commands to use Yarn

### DIFF
--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -38,14 +38,14 @@ create_preview_environment: False
 # If 'command' is None or missing, unit tests will be skipped
 unittest:
   image: 280296955917.dkr.ecr.us-east-2.amazonaws.com/dockerhub/library/node:22
-  command: "npm ci && npm test"
+  command: "yarn install --frozen-lockfile && yarn test"
   # coverage_file: None  # Optional: Path to coverage file if not in default location
 
 # Code Linting Configuration
 # If 'command' is None or missing, linting will be skipped
 lint:
   image: 280296955917.dkr.ecr.us-east-2.amazonaws.com/dockerhub/library/node:22
-  command: "npm ci && npm run lint"
+  command: "yarn install --frozen-lockfile && yarn run lint"
   # coverage_file: None  # Optional: Path to lint results file
 
 # SonarQube Code Analysis

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -44,8 +44,8 @@ unittest:
 # Code Linting Configuration
 # If 'command' is None or missing, linting will be skipped
 lint:
-  image: 280296955917.dkr.ecr.us-east-2.amazonaws.com/dockerhub/library/node:22
-  command: "yarn install --frozen-lockfile && yarn run lint"
+  image: None
+  command: None
   # coverage_file: None  # Optional: Path to lint results file
 
 # SonarQube Code Analysis

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -57,4 +57,4 @@ run_sonar_scanner: True
 # test_coverage_dir: Custom directory for test coverage output files
 # Default: "" (uses standard /app directory)
 # Example: "coverage" for projects that output to ./coverage/
-test_coverage_dir: "coverage"
+test_coverage_dir: ""


### PR DESCRIPTION
# What?

replaced npm with yarn in ci config

# Why?

npm failed cuz it was lacking package json lock from npm. but ther is yarn lock cuz the project uses yarn


