### PR TITLE
Task/flcrm 20528 add sketch  validation error support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@fulcrumapp/fulcrum-core",
+<<<<<<< HEAD
   "version": "1.5.9",
+=======
+  "version": "1.6.0",
+>>>>>>> ebb47f5 ([bump] fulcrum core version)
   "description": "Fulcrum Core",
   "homepage": "http://github.com/fulcrumapp/fulcrum-core",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@fulcrumapp/fulcrum-core",
-<<<<<<< HEAD
-  "version": "1.5.9",
-=======
   "version": "1.6.0",
->>>>>>> ebb47f5 ([bump] fulcrum core version)
   "description": "Fulcrum Core",
   "homepage": "http://github.com/fulcrumapp/fulcrum-core",
   "main": "dist/index.js",

--- a/src/validation/length-validation-error.js
+++ b/src/validation/length-validation-error.js
@@ -34,6 +34,8 @@ export default class LengthValidationError extends ElementValidationError {
       return this.audioElementMessage;
     } else if (this.element.isAttachmentElement) {
       return this.attachmentElementMessage;
+    } else if (this.element.isSketchElement) {
+      return this.sketchElementMessage;
     } else if (this.element.isRepeatableElement) {
       return this.repeatableElementMessage;
     }
@@ -189,6 +191,29 @@ export default class LengthValidationError extends ElementValidationError {
     } else if (this.isExactlyError) {
       return this.messageWithFormats("The field '%s' must have exactly 1 choice.",
                                      "The field '%s' must have exactly %s choices.",
+                                     this.element.minLength);
+    }
+
+    return '';
+  }
+
+  get sketchElementMessage() {
+    if (this.isAtLeastError) {
+      return this.messageWithFormats("The field '%s' must have at least 1 sketch.",
+                                     "The field '%s' must have at least %s sketches.",
+                                     this.element.minLength);
+    } else if (this.isAtMostError) {
+      return this.messageWithFormats("The field '%s' cannot have more than 1 sketch.",
+                                     "The field '%s' cannot have more than %s sketches.",
+                                     this.element.maxLength);
+    } else if (this.isBetweenError) {
+      return format("The field '%s' must have between %s and %s sketches.",
+                    this.label,
+                    this.element.minLength,
+                    this.element.maxLength);
+    } else if (this.isExactlyError) {
+      return this.messageWithFormats("The field '%s' must have exactly 1 sketch.",
+                                     "The field '%s' must have exactly %s sketches.",
                                      this.element.minLength);
     }
 

--- a/src/validation/length-validation-error.js
+++ b/src/validation/length-validation-error.js
@@ -245,7 +245,7 @@ export default class LengthValidationError extends ElementValidationError {
 
   messageWithFormats(singularFormat, pluralFormat, length) {
     if (length === 1) {
-      return format(singularFormat, this.label, length);
+      return format(singularFormat, this.label);
     }
 
     return format(pluralFormat, this.label, length);

--- a/src/validation/length-validation-error.js
+++ b/src/validation/length-validation-error.js
@@ -243,6 +243,15 @@ export default class LengthValidationError extends ElementValidationError {
     return '';
   }
 
+  /**
+   * Returns a formatted validation message using singular or plural form based on length.
+   *
+   * @param {string} singularFormat - Format string with exactly one %s placeholder (label).
+   *   The length is NOT passed to this format because it is always 1 in the singular case.
+   *   Including a second %s here will produce a literal "%s" in the output.
+   * @param {string} pluralFormat - Format string with two %s placeholders (label, length).
+   * @param {number} length - The numeric length value; determines which format is used.
+   */
   messageWithFormats(singularFormat, pluralFormat, length) {
     if (length === 1) {
       return format(singularFormat, this.label);

--- a/test/elements/choice-element.js
+++ b/test/elements/choice-element.js
@@ -1,6 +1,7 @@
 import setup from '../helper';
 
 import { ChoiceElement, ChoiceValue, Choice } from '../../src';
+import LengthValidationError from '../../src/validation/length-validation-error';
 
 let record = null;
 
@@ -160,5 +161,41 @@ describe('choice fields', () => {
     value.otherValues.should.eql(['Another']);
 
     value.otherValue.should.eql('Another');
+  });
+});
+
+describe('ChoiceElement length validation (messageWithFormats regression)', () => {
+  let field;
+
+  beforeEach(() => {
+    field = record.form.find('single_choice');
+  });
+
+  it('returns a singular at-least message without trailing artifact', () => {
+    field._minLength = 1;
+    field._maxLength = null;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Single Choice' must have at least 1 choice.");
+  });
+
+  it('returns a singular at-most message without trailing artifact', () => {
+    field._minLength = null;
+    field._maxLength = 1;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Single Choice' cannot have more than 1 choice.");
+  });
+
+  it('returns a singular exactly message without trailing artifact', () => {
+    field._minLength = 1;
+    field._maxLength = 1;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Single Choice' must have exactly 1 choice.");
+  });
+
+  it('returns a plural at-least message with the count', () => {
+    field._minLength = 3;
+    field._maxLength = null;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Single Choice' must have at least 3 choices.");
   });
 });

--- a/test/elements/sketch-element.js
+++ b/test/elements/sketch-element.js
@@ -47,7 +47,7 @@ describe('SketchElement length validation', () => {
     field._minLength = 1;
     field._maxLength = null;
     const error = new LengthValidationError(field);
-    error.message.should.eql("The field 'Sketch' must have at least 1 sketch. 1");
+    error.message.should.eql("The field 'Sketch' must have at least 1 sketch.");
   });
 
   it('returns an at-most message when maxLength is set', () => {
@@ -61,7 +61,7 @@ describe('SketchElement length validation', () => {
     field._minLength = null;
     field._maxLength = 1;
     const error = new LengthValidationError(field);
-    error.message.should.eql("The field 'Sketch' cannot have more than 1 sketch. 1");
+    error.message.should.eql("The field 'Sketch' cannot have more than 1 sketch.");
   });
 
   it('returns a between message when both min and max length are set', () => {
@@ -82,6 +82,6 @@ describe('SketchElement length validation', () => {
     field._minLength = 1;
     field._maxLength = 1;
     const error = new LengthValidationError(field);
-    error.message.should.eql("The field 'Sketch' must have exactly 1 sketch. 1");
+    error.message.should.eql("The field 'Sketch' must have exactly 1 sketch.");
   });
 });

--- a/test/elements/sketch-element.js
+++ b/test/elements/sketch-element.js
@@ -1,6 +1,7 @@
 import setup from '../helper';
 
 import { SketchElement, SketchValue } from '../../src';
+import LengthValidationError from '../../src/validation/length-validation-error';
 
 let record = null;
 
@@ -25,5 +26,62 @@ describe('dynamic elements fields', () => {
     value.should.be.instanceof(SketchValue);
 
     value.isEmpty.should.eql(false);
+  });
+});
+
+describe('SketchElement length validation', () => {
+  let field;
+
+  beforeEach(() => {
+    field = record.form.find('sketch');
+  });
+
+  it('returns an at-least message when minLength is set', () => {
+    field._minLength = 5;
+    field._maxLength = null;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Sketch' must have at least 5 sketches.");
+  });
+
+  it('returns a singular at-least message when minLength is 1', () => {
+    field._minLength = 1;
+    field._maxLength = null;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Sketch' must have at least 1 sketch. 1");
+  });
+
+  it('returns an at-most message when maxLength is set', () => {
+    field._minLength = null;
+    field._maxLength = 5;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Sketch' cannot have more than 5 sketches.");
+  });
+
+  it('returns a singular at-most message when maxLength is 1', () => {
+    field._minLength = null;
+    field._maxLength = 1;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Sketch' cannot have more than 1 sketch. 1");
+  });
+
+  it('returns a between message when both min and max length are set', () => {
+    field._minLength = 2;
+    field._maxLength = 5;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Sketch' must have between 2 and 5 sketches.");
+  });
+
+  it('returns an exactly message when min and max length are equal', () => {
+    field._minLength = 3;
+    field._maxLength = 3;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Sketch' must have exactly 3 sketches.");
+  });
+
+  it('returns a singular exactly message when min and max are 1', () => {
+    field._minLength = 1;
+    field._maxLength = 1;
+    const error = new LengthValidationError(field);
+    error.message.should.eql("The field 'Sketch' must have exactly 1 sketch. 1");
   });
 });


### PR DESCRIPTION
# What?

- Adds length validation error message support for `SketchElement` (at-least, at-most, between, exactly).
- Fixes a bug in `messageWithFormats` where `util.format` was passed an extra `length` argument for singular format strings, causing a trailing " 1" to be appended to all singular validation messages (e.g., "must have exactly 1 sketch. 1").
- Bumps package version to 1.6.0.

# Why?

Resolves [FLCRM-20528](https://fulcrumapp.atlassian.net/browse/FLCRM-20528). Sketch elements previously had no length validation error messages, causing them to silently return an empty string when min/max length constraints were violated. This brings sketch elements in line with photo, video, audio, and attachment elements which already have proper validation messages.

The `messageWithFormats` fix is a latent bug that affected all element types—singular format strings hardcode "1" in the text and only use a single `%s` for the label, but `util.format` was receiving `length` as an extra argument which it appended to the output.

# Testing

- All 157 existing + new unit tests pass (`npm test`).
- New test file `test/elements/sketch-element.js` covers all validation branches: at-least (plural/singular), at-most (plural/singular), between, and exactly (plural/singular).
- No config changes needed.
- To manually test: create a form with a sketch field that has min/max length constraints, then trigger validation and verify the error messages display correctly.
- you can test it manually using the `test-fulcrum-core-changes/SKILL.md`


NOTE TO AUTHOR: Notify Slack channel #chaos-env-updates of upcoming changes to this widely-used tool.


[FLCRM-20528]: https://fulcrumapp.atlassian.net/browse/FLCRM-20528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


https://github.com/user-attachments/assets/654dfe4e-d049-40db-8ad4-94c8f820476a

