### PR TITLE
Bug/flcrm 20494 align visibility rules between web and mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fulcrumapp/fulcrum-core",
-  "version": "1.5.7-dev.0",
+  "version": "1.5.7-dev.1",
   "description": "Fulcrum Core",
   "homepage": "http://github.com/fulcrumapp/fulcrum-core",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fulcrumapp/fulcrum-core",
-  "version": "1.5.3",
+  "version": "1.5.7-dev.0",
   "description": "Fulcrum Core",
   "homepage": "http://github.com/fulcrumapp/fulcrum-core",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fulcrumapp/fulcrum-core",
-  "version": "1.5.7-dev.2",
+  "version": "1.5.8",
   "description": "Fulcrum Core",
   "homepage": "http://github.com/fulcrumapp/fulcrum-core",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fulcrumapp/fulcrum-core",
-  "version": "1.5.7-dev.1",
+  "version": "1.5.7-dev.2",
   "description": "Fulcrum Core",
   "homepage": "http://github.com/fulcrumapp/fulcrum-core",
   "main": "dist/index.js",

--- a/src/elements/condition.js
+++ b/src/elements/condition.js
@@ -223,7 +223,7 @@ export default class Condition {
 
       const skipElement = referencedElement.isHidden
         || referencedElement.hasHiddenParent
-        || referencedElement._visibleConditionsBehavior === 'preserve';
+        || referencedElement.isPreserved;
 
       if (!skipElement) {
         isReferencedFieldSatisfied = Condition.shouldElementBeVisibleRecursive(referencedElement, record, values, cache);

--- a/src/values/form-value.ts
+++ b/src/values/form-value.ts
@@ -1,4 +1,6 @@
-import FormValueFactory from './form-value-factory';
+// Required for the lazy require() in FormValue.create — see comment there.
+// Using declare avoids adding @types/node as a dependency for a library package.
+declare const require: (id: string) => any;
 
 function notImplemented(): never {
   throw new Error('Not implemented');
@@ -71,6 +73,11 @@ export default class FormValue {
   }
 
   static create(element: any, attributes: any): FormValue {
-    return FormValueFactory.create(element, attributes);
+    // Lazy require to break the FormValue → FormValueFactory → subclasses → FormValue cycle.
+    // A top-level import is evaluated eagerly; Rollup cannot safely linearize the cycle in
+    // production builds, causing "Class extends value undefined" at runtime. The original
+    // form-value.js used this same pattern intentionally.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('./form-value-factory').default.create(element, attributes);
   }
 }

--- a/test/elements/condition.js
+++ b/test/elements/condition.js
@@ -1,5 +1,4 @@
 import setup from '../helper';
-import sinon from 'sinon';
 
 import Condition from '../../src/elements/condition';
 
@@ -79,41 +78,47 @@ describe('isSatisfied', () => {
 
     element._visibleConditionsBehavior = 'preserve';
 
-    sinon.stub(Condition, 'shouldElementBeVisible').returns(false);
+    const original = Condition.shouldElementBeVisible;
+    try {
+      Condition.shouldElementBeVisible = () => false;
 
-    const attributes = {
-      field_key: 'ae75',
-      operator: 'equal_to',
-      value: 'Test'
-    };
+      const attributes = {
+        field_key: 'ae75',
+        operator: 'equal_to',
+        value: 'Test'
+      };
 
-    const condition = new Condition(element, attributes);
+      const condition = new Condition(element, attributes);
 
-    const result = condition.isSatisfied(record, record.formValues, {});
+      const result = condition.isSatisfied(record, record.formValues, {});
 
-    result.should.eql(true);
-
-    Condition.shouldElementBeVisible.restore();
+      result.should.eql(true);
+    } finally {
+      Condition.shouldElementBeVisible = original;
+    }
   });
 
   it('should return false when a conditionally hidden field with "clear" has a matching value', () => {
     const element = record.form.get('ae75');
 
-    sinon.stub(Condition, 'shouldElementBeVisibleRecursive').returns(false);
+    const original = Condition.shouldElementBeVisibleRecursive;
+    try {
+      Condition.shouldElementBeVisibleRecursive = () => false;
 
-    const attributes = {
-      field_key: 'ae75',
-      operator: 'equal_to',
-      value: 'Test'
-    };
+      const attributes = {
+        field_key: 'ae75',
+        operator: 'equal_to',
+        value: 'Test'
+      };
 
-    const condition = new Condition(element, attributes);
+      const condition = new Condition(element, attributes);
 
-    const result = condition.isSatisfied(record, record.formValues, {});
+      const result = condition.isSatisfied(record, record.formValues, {});
 
-    result.should.eql(false);
-
-    Condition.shouldElementBeVisibleRecursive.restore();
+      result.should.eql(false);
+    } finally {
+      Condition.shouldElementBeVisibleRecursive = original;
+    }
   });
 
   it('should return true when a field inside a preserve section is conditionally hidden (inherited preserve)', () => {
@@ -124,21 +129,24 @@ describe('isSatisfied', () => {
     // is 'clear'. After the fix, isPreserved walks up and finds the parent, returning true.
     element._parent = { isPreserved: true };
 
-    sinon.stub(Condition, 'shouldElementBeVisibleRecursive').returns(false);
+    const original = Condition.shouldElementBeVisibleRecursive;
+    try {
+      Condition.shouldElementBeVisibleRecursive = () => false;
 
-    const attributes = {
-      field_key: 'ae75',
-      operator: 'equal_to',
-      value: 'Test'
-    };
+      const attributes = {
+        field_key: 'ae75',
+        operator: 'equal_to',
+        value: 'Test'
+      };
 
-    const condition = new Condition(element, attributes);
+      const condition = new Condition(element, attributes);
 
-    const result = condition.isSatisfied(record, record.formValues, {});
+      const result = condition.isSatisfied(record, record.formValues, {});
 
-    result.should.eql(true);
-
-    Condition.shouldElementBeVisibleRecursive.restore();
+      result.should.eql(true);
+    } finally {
+      Condition.shouldElementBeVisibleRecursive = original;
+    }
   });
 
   it('should return true when inner section has preserve and outer section has clear and is hidden (S7)', () => {
@@ -149,21 +157,24 @@ describe('isSatisfied', () => {
     // section's clear behavior does not override it.
     element._parent = { isPreserved: true };
 
-    sinon.stub(Condition, 'shouldElementBeVisibleRecursive').returns(false);
+    const original = Condition.shouldElementBeVisibleRecursive;
+    try {
+      Condition.shouldElementBeVisibleRecursive = () => false;
 
-    const attributes = {
-      field_key: 'ae75',
-      operator: 'equal_to',
-      value: 'Test'
-    };
+      const attributes = {
+        field_key: 'ae75',
+        operator: 'equal_to',
+        value: 'Test'
+      };
 
-    const condition = new Condition(element, attributes);
+      const condition = new Condition(element, attributes);
 
-    const result = condition.isSatisfied(record, record.formValues, {});
+      const result = condition.isSatisfied(record, record.formValues, {});
 
-    result.should.eql(true);
-
-    Condition.shouldElementBeVisibleRecursive.restore();
+      result.should.eql(true);
+    } finally {
+      Condition.shouldElementBeVisibleRecursive = original;
+    }
   });
 
   it('should return true when grandparent section has preserve and inner section and field have clear (transitive inheritance)', () => {
@@ -177,21 +188,24 @@ describe('isSatisfied', () => {
     };
     element._parent = innerSection;
 
-    sinon.stub(Condition, 'shouldElementBeVisibleRecursive').returns(false);
+    const original = Condition.shouldElementBeVisibleRecursive;
+    try {
+      Condition.shouldElementBeVisibleRecursive = () => false;
 
-    const attributes = {
-      field_key: 'ae75',
-      operator: 'equal_to',
-      value: 'Test'
-    };
+      const attributes = {
+        field_key: 'ae75',
+        operator: 'equal_to',
+        value: 'Test'
+      };
 
-    const condition = new Condition(element, attributes);
+      const condition = new Condition(element, attributes);
 
-    const result = condition.isSatisfied(record, record.formValues, {});
+      const result = condition.isSatisfied(record, record.formValues, {});
 
-    result.should.eql(true);
-
-    Condition.shouldElementBeVisibleRecursive.restore();
+      result.should.eql(true);
+    } finally {
+      Condition.shouldElementBeVisibleRecursive = original;
+    }
   });
 
   it('should return false when a field with no preserve ancestor is conditionally hidden', () => {
@@ -199,20 +213,23 @@ describe('isSatisfied', () => {
 
     // Neither the field nor any ancestor has preserve. isPreserved returns false,
     // so the visibility check runs and the hidden field's value is treated as blank.
-    sinon.stub(Condition, 'shouldElementBeVisibleRecursive').returns(false);
+    const original = Condition.shouldElementBeVisibleRecursive;
+    try {
+      Condition.shouldElementBeVisibleRecursive = () => false;
 
-    const attributes = {
-      field_key: 'ae75',
-      operator: 'equal_to',
-      value: 'Test'
-    };
+      const attributes = {
+        field_key: 'ae75',
+        operator: 'equal_to',
+        value: 'Test'
+      };
 
-    const condition = new Condition(element, attributes);
+      const condition = new Condition(element, attributes);
 
-    const result = condition.isSatisfied(record, record.formValues, {});
+      const result = condition.isSatisfied(record, record.formValues, {});
 
-    result.should.eql(false);
-
-    Condition.shouldElementBeVisibleRecursive.restore();
+      result.should.eql(false);
+    } finally {
+      Condition.shouldElementBeVisibleRecursive = original;
+    }
   });
 });

--- a/test/elements/condition.js
+++ b/test/elements/condition.js
@@ -115,4 +115,104 @@ describe('isSatisfied', () => {
 
     Condition.shouldElementBeVisibleRecursive.restore();
   });
+
+  it('should return true when a field inside a preserve section is conditionally hidden (inherited preserve)', () => {
+    const element = record.form.get('ae75');
+
+    // Parent section has visible_conditions_behavior: 'preserve'; field itself is 'clear' (default).
+    // Before the fix, isPreserved on the field would return false because _visibleConditionsBehavior
+    // is 'clear'. After the fix, isPreserved walks up and finds the parent, returning true.
+    element._parent = { isPreserved: true };
+
+    sinon.stub(Condition, 'shouldElementBeVisibleRecursive').returns(false);
+
+    const attributes = {
+      field_key: 'ae75',
+      operator: 'equal_to',
+      value: 'Test'
+    };
+
+    const condition = new Condition(element, attributes);
+
+    const result = condition.isSatisfied(record, record.formValues, {});
+
+    result.should.eql(true);
+
+    Condition.shouldElementBeVisibleRecursive.restore();
+  });
+
+  it('should return true when inner section has preserve and outer section has clear and is hidden (S7)', () => {
+    const element = record.form.get('ae75');
+
+    // Outer section has 'clear' with own conditions; inner section has 'preserve' (no own conditions).
+    // The inner preserve wins: isPreserved returns true at the inner section level and the outer
+    // section's clear behavior does not override it.
+    element._parent = { isPreserved: true };
+
+    sinon.stub(Condition, 'shouldElementBeVisibleRecursive').returns(false);
+
+    const attributes = {
+      field_key: 'ae75',
+      operator: 'equal_to',
+      value: 'Test'
+    };
+
+    const condition = new Condition(element, attributes);
+
+    const result = condition.isSatisfied(record, record.formValues, {});
+
+    result.should.eql(true);
+
+    Condition.shouldElementBeVisibleRecursive.restore();
+  });
+
+  it('should return true when grandparent section has preserve and inner section and field have clear (transitive inheritance)', () => {
+    const element = record.form.get('ae75');
+
+    // Two-level nesting: grandparent has preserve, inner section and field both have clear.
+    // isPreserved walks up: field delegates to inner, inner delegates to grandparent, grandparent returns true.
+    const grandparentSection = { isPreserved: true };
+    const innerSection = {
+      get isPreserved() { return grandparentSection.isPreserved; }
+    };
+    element._parent = innerSection;
+
+    sinon.stub(Condition, 'shouldElementBeVisibleRecursive').returns(false);
+
+    const attributes = {
+      field_key: 'ae75',
+      operator: 'equal_to',
+      value: 'Test'
+    };
+
+    const condition = new Condition(element, attributes);
+
+    const result = condition.isSatisfied(record, record.formValues, {});
+
+    result.should.eql(true);
+
+    Condition.shouldElementBeVisibleRecursive.restore();
+  });
+
+  it('should return false when a field with no preserve ancestor is conditionally hidden', () => {
+    const element = record.form.get('ae75');
+
+    // Neither the field nor any ancestor has preserve. isPreserved returns false,
+    // so the visibility check runs and the hidden field's value is treated as blank.
+    sinon.stub(Condition, 'shouldElementBeVisibleRecursive').returns(false);
+
+    const attributes = {
+      field_key: 'ae75',
+      operator: 'equal_to',
+      value: 'Test'
+    };
+
+    const condition = new Condition(element, attributes);
+
+    const result = condition.isSatisfied(record, record.formValues, {});
+
+    result.should.eql(false);
+
+    Condition.shouldElementBeVisibleRecursive.restore();
+  });
 });


### PR DESCRIPTION
# What?

- Makes `@fulcrumapp/fulcrum-core` usable in fulcrum-components (which currently points at `fulcrum-core`)
- Fixes a visibility rule issue

# Why?

https://fulcrumapp.atlassian.net/browse/FLCRM-20494

# Testing

- This can be tested in this preview environment: https://github.com/fulcrumapp/fulcrum/pull/10631

NOTE TO AUTHOR: Notify Slack channel #chaos-env-updates of upcoming changes to this widely-used tool.
